### PR TITLE
[Chore] Bump trace_viz version to 1.0.0 in `Gemfile.lock` and `version.rb`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trace_viz (0.0.2)
+    trace_viz (1.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/trace_viz/version.rb
+++ b/lib/trace_viz/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TraceViz
-  VERSION = "0.0.2"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
## Description

This PR introduces the **version update to 1.0.0** for the TraceViz gem. It marks the transition from development versions to the first production-ready release. The version bump aligns with the milestone for releasing TraceViz 1.0.0, encapsulating all the features, refinements, and testing completed in prior development cycles.

- Updates the gem version to **1.0.0**.
- Prepares for the official release of TraceViz with all finalized changes.
- Sets the stage for packaging and deployment of the production-ready gem.

## Type of Change

Check all that apply:
- [x] Other (please describe): Version update for the 1.0.0 release.

## How Has This Been Tested?

Since this PR involves only a version update:
- [x] Verified that `bundle exec rspec` passes all tests.
- [x] Ensured the gem builds correctly with the new version.

No additional testing was required for this change.

## Checklist

- [x] I have followed the [Ruby Style Guide](https://github.com/rubocop/ruby-style-guide).
- [x] I have performed a self-review of my code.
- [x] All existing and new tests pass.
- [x] I have updated the documentation (if needed), including `README.md` and `CHANGELOG.md`.

## Deployment Notes

- After merging, the new version should be published to RubyGems to make TraceViz 1.0.0 available to users.
- Ensure that the `CHANGELOG.md` and release notes on GitHub reflect the key highlights of version 1.0.0.

## Related Issues

- N/A

## Screenshots (if applicable)

- N/A
