### PR TITLE
[Update] Add documentation links to README and gemspec for trace_viz

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,10 @@ TraceViz provides extensive configuration options to customize tracing behavior.
 - **Default Skipped Classes**: The following standard library classes are excluded by default when `:exclude_default_classes` is enabled:
   - `Object`, `String`, `Array`, `Hash`, `Numeric`, `Integer`, `Float`, `Symbol`, `Kernel`, `Module`, `Class`, `Range`, `Regexp`, `Set`, `Gem`.
 
+## Documentation
+
+For detailed API documentation, please visit [RubyDoc for trace_viz](https://www.rubydoc.info/gems/trace_viz).
+
 ## Development
 
 To set up your development environment:

--- a/lib/trace_viz.rb
+++ b/lib/trace_viz.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# For detailed documentation, please refer to https://www.rubydoc.info/gems/trace_viz
+
 require "trace_viz/version"
 require "trace_viz/errors"
 require "trace_viz/core"

--- a/trace_viz.gemspec
+++ b/trace_viz.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
+  spec.metadata["documentation_uri"] = "https://www.rubydoc.info/gems/trace_viz"
   spec.metadata["changelog_uri"] = "https://github.com/patrick204nqh/trace_viz/blob/main/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.


### PR DESCRIPTION
## Description

- Enhances the documentation by linking to [RubyDoc for TraceViz](https://www.rubydoc.info/gems/trace_viz).
- Clarifies how to navigate the documentation for better onboarding.

## Type of Change

Check all that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?

Describe the tests you ran to verify your changes:

- [x] Running `bundle exec rspec` passes all tests
- [x] Added or updated specs for new functionality
- [ ] Tested changes on different Ruby versions if relevant

If you have any manual testing steps, please detail them here.

## Checklist

- [x] I have followed the [Ruby Style Guide](https://github.com/rubocop/ruby-style-guide).
- [x] I have performed a self-review of my code.
- [ ] I have added or updated tests as needed.
- [x] All existing and new tests pass.
- [x] I have updated the documentation (if needed), including `README.md` and `CHANGELOG.md`.
- [x] I have considered the impact on users and documented any required changes or upgrades.

## Deployment Notes

none

## Related Issues

none

## Screenshots (if applicable)

none
